### PR TITLE
fix: bitcoin.conf missing line breaks

### DIFF
--- a/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
@@ -61,7 +61,11 @@ services:
     volumes:
       - bitcoin_data:/data
     environment:
-      - BITCOIN_EXTRA_ARGS=rpcuser=bitcoin rpcpassword=bitcoin prune=550 assumevalid=${BITCOIN_ASSUME_VALID}
+      - BITCOIN_EXTRA_ARGS=
+        rpcuser=bitcoin
+        rpcpassword=bitcoin
+        prune=550
+        assumevalid=${BITCOIN_ASSUME_VALID}
     restart: always
     
 

--- a/downloader.sh
+++ b/downloader.sh
@@ -408,7 +408,7 @@ warn_bitcoind_sync() {
   echo
   echo "WARNING: Your new local bitcoind node is now syncing"
   echo "This may take a while, you can check the progress with:"
-  echo "docker exec -it bitcoind bitcoin-cli getblockchaininfo"
+  echo "docker exec -it fedimint-service-bitcoind-1 bitcoin-cli getblockchaininfo"
   echo
   echo "Once the sync is complete, you can access the Guardian at:"
   echo "https://$host_name"


### PR DESCRIPTION
Fixes https://github.com/fedimint/fedimint-docker/issues/1

- Makes BITCOIN_EXTRA_ARGS multiline
- Fixes naming for local bitcoind docker container 