### PR TITLE
fix: bitcoind local conf multi line issue

### DIFF
--- a/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
     volumes:
       - bitcoin_data:/data
     environment:
-      - BITCOIN_EXTRA_ARGS=
+      BITCOIN_EXTRA_ARGS: |
         rpcuser=bitcoin
         rpcpassword=bitcoin
         prune=550


### PR DESCRIPTION
Before:
```shell
mainnet=1
[main]
printtoconsole=1
rpcallowip=::/0
rpcuser=bitcoin
 rpcpassword=bitcoin prune=550 assumevalid=
```

After
```shell
mainnet=1
[main]
printtoconsole=1
rpcallowip=::/0
rpcuser=bitcoin
rpcpassword=bitcoin
prune=550
assumevalid=
```

Sry, I overlooked the other PR. YAML files can be tricky occasionally.
