### PR TITLE
feat: use cookie_file instead of auth

### DIFF
--- a/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
@@ -20,11 +20,13 @@ services:
     container_name: fedimintd
     volumes:
       - fedimintd_data:/data
+      - bitcoind_data:/bitcoind_data
     ports:
       - "0.0.0.0:8173:8173"
     environment:
       - FM_DEFAULT_BITCOIND_RPC_KIND=${FM_DEFAULT_BITCOIND_RPC_KIND}
       - FM_DEFAULT_BITCOIND_RPC_URL=${FM_DEFAULT_BITCOIND_RPC_URL}
+      - FM_BITCOIND_COOKIE_FILE_ENV=/bitcoind_data/.cookie
       - FM_BITCOIN_NETWORK=${FM_BITCOIN_NETWORK}
       - FM_BIND_P2P=0.0.0.0:8173
       - FM_P2P_URL=fedimint://${FM_DOMAIN}:8173
@@ -62,14 +64,12 @@ services:
       - 0.0.0.0:8332:8332
       - 0.0.0.0:8333:8333
     volumes:
-      - bitcoin_data:/data
+      - bitcoind_data:/data
     environment:
       BITCOIN_EXTRA_ARGS: |
         rpcallowip=0.0.0.0/0
         rpcbind=0.0.0.0
         rpcport=8332
-        rpcuser=bitcoin
-        rpcpassword=${BITCOIN_RPC_PASSWORD}
         prune=550
         assumevalid=${BITCOIN_ASSUME_VALID}
     restart: always
@@ -78,4 +78,4 @@ services:
 volumes:
   letsencrypt_data:
   fedimintd_data:
-  bitcoin_data:
+  bitcoind_data:


### PR DESCRIPTION
Uses the generated cookie file by sharing the bitcoin_volume instead of the user/pass, needed for new bitcoin versions > 0.26.

Fedimint doesn't look like it's picking up the cookie file though which is weird, I'm definitely setting it correctly in the container:

```
}bash-5.2# echo $FM_BITCOIND_COOKIE_FILE_ENV
/bitcoind_data/.cookie
bash-5.2# cat /bitcoind_data/.cookie
__cookie__:c575d3ddde3a9439a0e0d113b07280887b769bf9cdfb0954f8de0c19898c3befbash-5.2# exit
```

and that should be getting picked up by the bitcoincore function:

```
pub fn from_url_to_url_auth(url: &SafeUrl) -> anyhow::Result<(String, Auth)> {
    Ok((
        (if let Some(port) = url.port() {
            format!(
                "{}://{}:{port}",
                url.scheme(),
                url.host_str().unwrap_or("127.0.0.1")
            )
        } else {
            format!(
                "{}://{}",
                url.scheme(),
                url.host_str().unwrap_or("127.0.0.1")
            )
        }),
        match (
            !url.username().is_empty(),
            env::var(FM_BITCOIND_COOKIE_FILE_ENV),
        ) {
            (true, Ok(_)) => {
                bail!("When {FM_BITCOIND_COOKIE_FILE_ENV} is set, the url auth part must be empty.")
            }
            (true, Err(_)) => Auth::UserPass(
                url.username().to_owned(),
                url.password()
                    .ok_or_else(|| format_err!("Password missing for {}", url.username()))?
                    .to_owned(),
            ),
            (false, Ok(path)) => Auth::CookieFile(PathBuf::from(path)),
            (false, Err(_)) => Auth::None,
        },
    ))
}
```
but whenever I try I get jsonrpc errors when fedimint tries starting the dkg