### PR TITLE
chore: version bumping fedimint and gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repo contains a downloader script and various docker-compose configurations for running a Fedimint Guardian or a Fedimint Lightning Gateway.
 
+Current version of Fedimintd and Gatewayd: `v0.4.3`
+Current version of UI: `0.4.3`
+
 ## Downloader Script
 
 This script will create and configure a docker-compose.yaml file and a .env file in a directory named `fedimint-service`

--- a/configurations/gateway_mainnet_cln_local/docker-compose.yaml
+++ b/configurations/gateway_mainnet_cln_local/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
     restart: always
 
   gateway-ui:
-    image: fedimintui/gateway-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:
       - "0.0.0.0:3001:3001"
@@ -72,11 +72,11 @@ services:
     restart: always
     platform: linux/amd64
     labels:
-        - "traefik.enable=true"
-        - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
-        - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
-        - "traefik.http.routers.gateway-ui.entrypoints=websecure"
-        - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
+      - "traefik.enable=true"
+      - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
+      - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
+      - "traefik.http.routers.gateway-ui.entrypoints=websecure"
+      - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
 
 volumes:
   letsencrypt_data:

--- a/configurations/gateway_mainnet_ldk_local/docker-compose.yaml
+++ b/configurations/gateway_mainnet_ldk_local/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
-    image: fedimintui/gateway-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:
       - "0.0.0.0:3001:3001"
@@ -62,11 +62,11 @@ services:
     restart: always
     platform: linux/amd64
     labels:
-        - "traefik.enable=true"
-        - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
-        - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
-        - "traefik.http.routers.gateway-ui.entrypoints=websecure"
-        - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
+      - "traefik.enable=true"
+      - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
+      - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
+      - "traefik.http.routers.gateway-ui.entrypoints=websecure"
+      - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
 
 volumes:
   letsencrypt_data:

--- a/configurations/gateway_mainnet_lnd_remote/docker-compose.yaml
+++ b/configurations/gateway_mainnet_lnd_remote/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
-    image: fedimintui/gateway-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:
       - "0.0.0.0:3001:3001"
@@ -67,11 +67,11 @@ services:
     restart: always
     platform: linux/amd64
     labels:
-        - "traefik.enable=true"
-        - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
-        - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
-        - "traefik.http.routers.gateway-ui.entrypoints=websecure"
-        - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
+      - "traefik.enable=true"
+      - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
+      - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
+      - "traefik.http.routers.gateway-ui.entrypoints=websecure"
+      - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
 
 volumes:
   letsencrypt_data:

--- a/configurations/gateway_mutinynet_ldk/docker-compose.yaml
+++ b/configurations/gateway_mutinynet_ldk/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
-    image: fedimintui/gateway-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:
       - "0.0.0.0:3001:3001"
@@ -62,11 +62,11 @@ services:
     restart: always
     platform: linux/amd64
     labels:
-        - "traefik.enable=true"
-        - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
-        - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
-        - "traefik.http.routers.gateway-ui.entrypoints=websecure"
-        - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
+      - "traefik.enable=true"
+      - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
+      - "traefik.http.routers.gateway-ui.rule=Host(`${FM_GATEWAY_DOMAIN}`)"
+      - "traefik.http.routers.gateway-ui.entrypoints=websecure"
+      - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
 
 volumes:
   letsencrypt_data:

--- a/configurations/gateway_mutinynet_ldk/docker-compose.yaml
+++ b/configurations/gateway_mutinynet_ldk/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     restart: always
 
   gatewayd:
-    image: fedimint/gatewayd:v0.4.1
+    image: fedimint/gatewayd:v0.4.3
     command: gatewayd ldk
     environment:
       # Path to folder containing gateway config and data files

--- a/configurations/gateway_mutinynet_lnd_local/docker-compose.yaml
+++ b/configurations/gateway_mutinynet_lnd_local/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     restart: always
 
   gatewayd:
-    image: fedimint/gatewayd:v0.4.1
+    image: fedimint/gatewayd:v0.4.3
     container_name: gatewayd
     command: gatewayd lnd
     environment:

--- a/configurations/gateway_mutinynet_lnd_local/docker-compose.yaml
+++ b/configurations/gateway_mutinynet_lnd_local/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
-    image: fedimintui/gateway-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     container_name: gateway-ui
     environment:
       - PORT=80
@@ -60,11 +60,11 @@ services:
     restart: always
     platform: linux/amd64
     labels:
-        - "traefik.enable=true"
-        - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
-        - "traefik.http.routers.gateway-ui.rule=Host(`gateway-ui.${FM_GATEWAY_DOMAIN}`)"
-        - "traefik.http.routers.gateway-ui.entrypoints=websecure"
-        - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
+      - "traefik.enable=true"
+      - "traefik.http.services.gateway-ui.loadbalancer.server.port=80"
+      - "traefik.http.routers.gateway-ui.rule=Host(`gateway-ui.${FM_GATEWAY_DOMAIN}`)"
+      - "traefik.http.routers.gateway-ui.entrypoints=websecure"
+      - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
 
   lnd:
     image: lightninglabs/lnd:v0.18.2-beta

--- a/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:
       - PORT=80
@@ -54,7 +54,7 @@ services:
       - "traefik.http.routers.guardian-ui.rule=Host(`${FM_DOMAIN}`)"
       - "traefik.http.routers.guardian-ui.entrypoints=websecure"
       - "traefik.http.routers.guardian-ui.tls.certresolver=myresolver"
-  
+
   bitcoind:
     image: btcpayserver/bitcoin:26.0
     container_name: bitcoind
@@ -73,7 +73,6 @@ services:
         prune=550
         assumevalid=${BITCOIN_ASSUME_VALID}
     restart: always
-    
 
 volumes:
   letsencrypt_data:

--- a/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
-    image: fedimint/fedimintd:v0.4.1
+    image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
       - fedimintd_data:/data

--- a/configurations/guardian_mainnet_bitcoind_remote/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_remote/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:
       - PORT=80

--- a/configurations/guardian_mainnet_bitcoind_remote/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_remote/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
-    image: fedimint/fedimintd:v0.4.1
+    image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
       - fedimintd_data:/data

--- a/configurations/guardian_mainnet_esplora/docker-compose.yaml
+++ b/configurations/guardian_mainnet_esplora/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:
       - PORT=80

--- a/configurations/guardian_mainnet_esplora/docker-compose.yaml
+++ b/configurations/guardian_mainnet_esplora/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
-    image: fedimint/fedimintd:v0.4.1
+    image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
       - fedimintd_data:/data

--- a/configurations/guardian_mutinynet_bitcoind/docker-compose.yaml
+++ b/configurations/guardian_mutinynet_bitcoind/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
-    image: fedimint/fedimintd:v0.4.1
+    image: fedimint/fedimintd:v0.4.3
     volumes:
       - fedimintd_data:/data
     ports:

--- a/configurations/guardian_mutinynet_bitcoind/docker-compose.yaml
+++ b/configurations/guardian_mutinynet_bitcoind/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.4.1
+    image: fedimintui/fedimint-ui:0.4.3
     environment:
       - PORT=80
       - REACT_APP_FM_CONFIG_API=wss://${FM_DOMAIN}/ws/

--- a/configurations/guardian_mutinynet_esplora/docker-compose.yaml
+++ b/configurations/guardian_mutinynet_esplora/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
-    image: fedimint/fedimintd:v0.4.1
+    image: fedimint/fedimintd:v0.4.3
     volumes:
       - fedimintd_data:/data
     ports:

--- a/configurations/guardian_mutinynet_esplora/docker-compose.yaml
+++ b/configurations/guardian_mutinynet_esplora/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     environment:
       - PORT=80
       - REACT_APP_FM_CONFIG_API=wss://${FM_DOMAIN}/ws/

--- a/configurations/guardian_testnet_esplora/docker-compose.yaml
+++ b/configurations/guardian_testnet_esplora/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
-    image: fedimintui/guardian-ui:0.4.2
+    image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:
       - PORT=80

--- a/configurations/guardian_testnet_esplora/docker-compose.yaml
+++ b/configurations/guardian_testnet_esplora/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
-    image: fedimint/fedimintd:v0.4.1
+    image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
       - fedimintd_data:/data

--- a/scripts/update-fedimint.sh
+++ b/scripts/update-fedimint.sh
@@ -12,3 +12,7 @@ find configurations -name docker-compose.yaml | while read -r file; do
   sed -i '' "s|image: fedimint/fedimintd:v[0-9.]*|image: fedimint/fedimintd:v$version|g" "$file"
   echo "Updated Fedimintd and Gatewayd version to $version in $file"
 done
+
+# Update README.md
+sed -i '' "s|Current version of Fedimintd and Gatewayd: \`v[0-9.]*\`|Current version of Fedimintd and Gatewayd: \`v$version\`|g" README.md
+echo "Updated version in README.md to $version"

--- a/scripts/update-ui.sh
+++ b/scripts/update-ui.sh
@@ -9,8 +9,8 @@ fi
 
 # Update docker-compose.yaml files
 find configurations -name docker-compose.yaml | while read -r file; do
-  sed -i '' "s|image: fedimintui/guardian-ui:[0-9.]*|image: fedimintui/guardian-ui:$version|g" "$file"
-  sed -i '' "s|image: fedimintui/gateway-ui:[0-9.]*|image: fedimintui/gateway-ui:$version|g" "$file"
+  sed -i '' "s|image: fedimintui/fedimint-ui:[0-9.]*|image: fedimintui/fedimint-ui:$version|g" "$file"
+  sed -i '' "s|image: fedimintui/fedimint-ui:[0-9.]*|image: fedimintui/fedimint-ui:$version|g" "$file"
   echo "Updated Guardian and Gateway UI version to $version in $file"
 done
 

--- a/scripts/update-ui.sh
+++ b/scripts/update-ui.sh
@@ -7,8 +7,13 @@ if [ -z "$version" ] || ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+# Update docker-compose.yaml files
 find configurations -name docker-compose.yaml | while read -r file; do
   sed -i '' "s|image: fedimintui/guardian-ui:[0-9.]*|image: fedimintui/guardian-ui:$version|g" "$file"
   sed -i '' "s|image: fedimintui/gateway-ui:[0-9.]*|image: fedimintui/gateway-ui:$version|g" "$file"
   echo "Updated Guardian and Gateway UI version to $version in $file"
 done
+
+# Update README.md
+sed -i '' "s|Current version of UI: \`v[0-9.]*\`|Current version of UI: \`v$version\`|g" README.md
+echo "Updated version in README.md to $version"


### PR DESCRIPTION
Bumps everything to 0.4.3 and uses new fedimint-ui docker image