### PR TITLE
fix: mutinynet esplora default env

### DIFF
--- a/configurations/guardian_mutinynet_esplora/.env
+++ b/configurations/guardian_mutinynet_esplora/.env
@@ -1,5 +1,5 @@
 # Set up a domain that points to the ipv4 address of the machine fedimintd is being deployed to
-FM_DOMAIN=my-super-host.com
+FM_DOMAIN=
 
 FM_BITCOIN_RPC_KIND=esplora
-FM_BITCOIN_RPC_URL=https://blockstream.info/api/
+FM_BITCOIN_RPC_URL=https://mutinynet.com/api/


### PR DESCRIPTION
- without this the Mutinynet Esplora setup would fail to prompt the user for a domain so the setup is far less seamless