### PR TITLE
chore: configure a logging that rotates logs

### DIFF
--- a/configurations/gateway_mainnet_cln_local/docker-compose.yaml
+++ b/configurations/gateway_mainnet_cln_local/docker-compose.yaml
@@ -1,5 +1,7 @@
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -18,6 +20,8 @@ services:
     restart: always
 
   gatewayd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/gatewayd:v0.4.3
     container_name: gatewayd
     command: gatewayd cln --cln-extension-addr=http://cln:3301
@@ -46,6 +50,8 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   cln:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/cln-light-gateway:master
     container_name: cln
     environment:
@@ -59,6 +65,8 @@ services:
     restart: always
 
   gateway-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:

--- a/configurations/gateway_mainnet_ldk_local/docker-compose.yaml
+++ b/configurations/gateway_mainnet_ldk_local/docker-compose.yaml
@@ -1,5 +1,7 @@
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -18,6 +20,8 @@ services:
     restart: always
 
   gatewayd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/gatewayd:master
     command: gatewayd ldk
     environment:
@@ -49,6 +53,8 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:

--- a/configurations/gateway_mainnet_lnd_remote/docker-compose.yaml
+++ b/configurations/gateway_mainnet_lnd_remote/docker-compose.yaml
@@ -1,5 +1,7 @@
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -18,6 +20,8 @@ services:
     restart: always
 
   gatewayd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/gatewayd:v0.4.3
     command: gatewayd lnd
     ports:
@@ -54,6 +58,8 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:

--- a/configurations/gateway_mutinynet_ldk/docker-compose.yaml
+++ b/configurations/gateway_mutinynet_ldk/docker-compose.yaml
@@ -1,5 +1,7 @@
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -18,6 +20,8 @@ services:
     restart: always
 
   gatewayd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/gatewayd:v0.4.3
     command: gatewayd ldk
     environment:
@@ -49,6 +53,8 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     # image: gateway-ui
     ports:

--- a/configurations/gateway_mutinynet_lnd_local/docker-compose.yaml
+++ b/configurations/gateway_mutinynet_lnd_local/docker-compose.yaml
@@ -3,6 +3,8 @@ version: "3"
 
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -21,6 +23,8 @@ services:
     restart: always
 
   gatewayd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/gatewayd:v0.4.3
     container_name: gatewayd
     command: gatewayd lnd
@@ -49,6 +53,8 @@ services:
       - "traefik.http.routers.gatewayd.tls.certresolver=myresolver"
 
   gateway-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     container_name: gateway-ui
     environment:
@@ -67,6 +73,8 @@ services:
       - "traefik.http.routers.gateway-ui.tls.certresolver=myresolver"
 
   lnd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: lightninglabs/lnd:v0.18.2-beta
     container_name: lnd
     entrypoint: bash
@@ -83,6 +91,8 @@ services:
     restart: always
 
   bitcoind:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/mutinynet-bitcoind:master
     container_name: bitcoind
     command: --rpcuser=bitcoin --rpcpassword=bitcoin -zmqpubrawblock=tcp://[::]:48332 -zmqpubrawtx=tcp://[::]:48333

--- a/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_local/docker-compose.yaml
@@ -1,6 +1,8 @@
 # See the .env file for config options
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -16,6 +18,8 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
@@ -40,6 +44,8 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:
@@ -56,6 +62,8 @@ services:
       - "traefik.http.routers.guardian-ui.tls.certresolver=myresolver"
 
   bitcoind:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: btcpayserver/bitcoin:26.0
     container_name: bitcoind
     ports:

--- a/configurations/guardian_mainnet_bitcoind_remote/docker-compose.yaml
+++ b/configurations/guardian_mainnet_bitcoind_remote/docker-compose.yaml
@@ -1,6 +1,8 @@
 # See the .env file for config options
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -16,6 +18,8 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
@@ -40,6 +44,8 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:

--- a/configurations/guardian_mainnet_esplora/docker-compose.yaml
+++ b/configurations/guardian_mainnet_esplora/docker-compose.yaml
@@ -1,6 +1,8 @@
 # See the .env file for config options
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -16,6 +18,8 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
@@ -40,6 +44,8 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:

--- a/configurations/guardian_mutinynet_bitcoind/docker-compose.yaml
+++ b/configurations/guardian_mutinynet_bitcoind/docker-compose.yaml
@@ -4,6 +4,8 @@ version: "3.3"
 
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -19,6 +21,8 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/fedimintd:v0.4.3
     volumes:
       - fedimintd_data:/data
@@ -41,6 +45,8 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     environment:
       - PORT=80

--- a/configurations/guardian_mutinynet_esplora/docker-compose.yaml
+++ b/configurations/guardian_mutinynet_esplora/docker-compose.yaml
@@ -4,6 +4,8 @@ version: "3.3"
 
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -19,6 +21,8 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/fedimintd:v0.4.3
     volumes:
       - fedimintd_data:/data
@@ -41,6 +45,8 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     environment:
       - PORT=80

--- a/configurations/guardian_testnet_esplora/docker-compose.yaml
+++ b/configurations/guardian_testnet_esplora/docker-compose.yaml
@@ -1,6 +1,8 @@
 # See the .env file for config options
 services:
   traefik:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: "traefik:v2.10"
     container_name: "traefik"
     command:
@@ -16,6 +18,8 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   fedimintd:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimint/fedimintd:v0.4.3
     container_name: fedimintd
     volumes:
@@ -40,6 +44,8 @@ services:
       - "traefik.http.routers.fedimintd.tls.certresolver=myresolver"
 
   guardian-ui:
+    logging:
+      driver: "local" # Do some log rotation by default
     image: fedimintui/fedimint-ui:0.4.3
     container_name: guardian-ui
     environment:


### PR DESCRIPTION

From https://docs.docker.com/engine/logging/configure/
> Tip
> 
> Use the local logging driver to prevent disk-exhaustion. By default, no log-rotation is performed. As a result, log-files stored by the default [json-file logging driver](https://docs.docker.com/engine/logging/drivers/json-file/) logging driver can cause a significant amount of disk space to be used for containers that generate much output, which can lead to disk space exhaustion.
> 
> Docker keeps the json-file logging driver (without log-rotation) as a default to remain backward compatibility with older versions of Docker, and for situations where Docker is used as runtime for Kubernetes.
> 
> For other situations, the local logging driver is recommended as it performs log-rotation by default, and uses a more efficient file format. Refer to the [Configure the default logging driver](https://docs.docker.com/engine/logging/configure/#configure-the-default-logging-driver) section below to learn how to configure the local logging driver as a default, and the [local file logging driver](https://docs.docker.com/engine/logging/drivers/local/) page for more details about the local logging driver.